### PR TITLE
fix: fix options from being overwritten on multiple calls

### DIFF
--- a/options.go
+++ b/options.go
@@ -37,12 +37,15 @@ func WithPlaceHolder(p Placeholder) Option {
 
 func WithFuncMap(funcs template.FuncMap) Option {
 	return newFuncOption(func(o *options) error {
-		for k := range funcs {
+		if o.funcs == nil {
+			o.funcs = template.FuncMap{}
+		}
+		for k, v := range funcs {
 			if k == "_sql_parser_" {
 				return fmt.Errorf("invalid function name, _sql_parser_ is reserved")
 			}
+			o.funcs[k] = v
 		}
-		o.funcs = funcs
 		return nil
 	})
 }


### PR DESCRIPTION
This was surfaced by having a global functions map. If compile was called twice with the same function map tqla would fail due to a conflict on including the internal _sql_parse_ function. This update ensures we do not re-use the same map. 